### PR TITLE
Adds a singleton behavior to the Configuration::get() method

### DIFF
--- a/spec/ConfigurationSpec.php
+++ b/spec/ConfigurationSpec.php
@@ -9,8 +9,10 @@
 
 namespace spec\Slick\Configuration;
 
+use PhpSpec\Exception\Example\FailureException;
 use Slick\Configuration\Configuration;
 use PhpSpec\ObjectBehavior;
+use Slick\Configuration\ConfigurationInterface;
 use Slick\Configuration\Driver\Environment;
 use Slick\Configuration\Driver\Ini;
 use Slick\Configuration\Driver\Php;
@@ -84,6 +86,26 @@ class ConfigurationSpec extends ObjectBehavior
         $chain->priorityList()->asArray()[1]->shouldBeAnInstanceOf(Php::class);
         $chain->priorityList()->asArray()[2]->shouldBeAnInstanceOf(Ini::class);
 
+    }
+
+    function it_can_be_created_through_get()
+    {
+        $this->beConstructedThrough('get', [$this->settingsFile]);
+        $this->shouldHaveType(PriorityConfigurationChain::class);
+        $object = Configuration::get('settings');
+        if ($this->getWrappedObject() !== $object) {
+            throw new FailureException("Its not the same object...");
+        }
+    }
+
+    function it_can_be_created_through_create()
+    {
+        $this->beConstructedThrough('create', [$this->settingsFile]);
+        $this->shouldHaveType(PriorityConfigurationChain::class);
+        $object = Configuration::get('settings');
+        if ($this->getWrappedObject() === $object) {
+            throw new FailureException("Its is the same object...");
+        }
     }
 
 }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -49,6 +49,11 @@ final class Configuration
     ];
 
     /**
+     * @var null|ConfigurationInterface
+     */
+    private static $instance;
+
+    /**
      * Creates a configuration factory
      *
      * @param string|array $options
@@ -62,7 +67,9 @@ final class Configuration
     }
 
     /**
-     * Creates a ConfigurationInterface with passed arguments
+     * Returns the last ConfigurationInterface
+     *
+     * If there is no configuration created it will use passed arguments to create one
      *
      * @param string|array $fileName
      * @param null         $driverClass
@@ -70,6 +77,22 @@ final class Configuration
      * @return ConfigurationInterface|PriorityConfigurationChain
      */
     public static function get($fileName, $driverClass = null)
+    {
+        if (self::$instance === null) {
+            self::$instance = self::create($fileName, $driverClass);
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Creates a ConfigurationInterface with passed arguments
+     *
+     * @param string|array $fileName
+     * @param null         $driverClass
+     *
+     * @return ConfigurationInterface|PriorityConfigurationChain
+     */
+    public static function create($fileName, $driverClass = null)
     {
         $configuration = new Configuration($fileName, $driverClass);
         return $configuration->initialize();


### PR DESCRIPTION
## Description

When using `Configuration::get()` should return the first created instance of settings. Normally the configuration settings is created on app bootstrap processes and used through the rest of the run.

In some implementations, more often when other packages used default settings, use the  `Configuration::get()` but it couldn't determine the path where settings file is loading the package defaults instead.

Creating a *singleton* behavior for the `Configuration::get()` will solve the problem.
Meanwhile a new method `Configuration::create()` is created to always return a new version of the configuration object.

## Motivation and context

I was having problems with a legacy application that had a package that loads a default settings.

It fixes #4 

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!